### PR TITLE
Multiple urls + new table schema

### DIFF
--- a/scraper/CompetitionScraper.py
+++ b/scraper/CompetitionScraper.py
@@ -11,8 +11,8 @@ from scraper.ClubScraper import ClubScraper
 
 
 class CompetitionScraper:
-    def __init__(self, competition_url: str):
-        self._url = competition_url
+    def __init__(self, competition_urls: list):
+        self._competitions = competition_urls
         self._table = None
         self.teams = dict()
         self.con = sqlite3.connect('./players.sqlite3')
@@ -40,11 +40,12 @@ class CompetitionScraper:
         Looks over all of the rows of players on this page.
     '''
     def scrape_competition(self) -> None:
-        content = requests.get(self._url, headers=ScraperConstants.HEADS).content
-        soup = BeautifulSoup(content, features="html.parser")
-        self._table = soup.find("table", {"class": "items"})
-        self._scrape_table("odd")
-        self._scrape_table("even")
+        for url in self._competitions:
+            content = requests.get(url, headers=ScraperConstants.HEADS).content
+            soup = BeautifulSoup(content, features="html.parser")
+            self._table = soup.find("table", {"class": "items"})
+            self._scrape_table("odd")
+            self._scrape_table("even")
 
     def scrape_players(self) -> None:
         for name in self.teams:
@@ -59,10 +60,10 @@ class CompetitionScraper:
         players = club_scraper.scrape_club()  
         for p in players:
             player_id = self.cur.lastrowid
-            print(f"Inserting {p.name} as {player_id}")
-            insert_values = (p.number, p.name, p.position, p.dob, str(p.nationalities), p.value)
+            insert_values = (club_name, p.number, p.name, p.position, p.dob, str(p.nationalities), p.value)
             self.cur.execute(ScraperConstants.INSERT_PLAYER_QUERY, insert_values)
         self.con.commit()
+
     '''
         Prints out all key value pairs of (name, club_info dictionary).
     '''

--- a/scraper/ScraperConstants.py
+++ b/scraper/ScraperConstants.py
@@ -14,9 +14,12 @@ IT1_URL: Final[str] = "https://www.transfermarkt.us/serie-a/startseite/wettbewer
 L1_URL: Final[str] = "https://www.transfermarkt.us/1-bundesliga/startseite/wettbewerb/L1"
 FR1_URL: Final[str] = "https://www.transfermarkt.us/ligue-1/startseite/wettbewerb/FR1"
 
+ALL_LEAGE_URLS: Final[list] = [GB1_URL, ES1_URL, IT1_URL, FR1_URL]
+
 CREATE_TABLE_QUERY: Final[str] = """
     CREATE TABLE players(
         id integer PRIMARY KEY,
+        club_name text,
         number text,
         name text,
         position text,
@@ -27,6 +30,6 @@ CREATE_TABLE_QUERY: Final[str] = """
 
 INSERT_PLAYER_QUERY: Final[str] = """
         INSERT INTO players
-        (number, name, position, dob, nationalities, value)
-        VALUES (?, ?, ?, ?, ?, ?)
+        (club_name, number, name, position, dob, nationalities, value)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
     """       

--- a/test_runner.py
+++ b/test_runner.py
@@ -2,4 +2,4 @@ import scraper.ScraperConstants as ScraperConstants
 from tests import test_scraper as t_s
 
 if __name__ == '__main__':
-    t_s.generic_test_scrape(ScraperConstants.GB1_URL)
+    t_s.generic_test_scrape(ScraperConstants.ALL_LEAGE_URLS)


### PR DESCRIPTION
CompetitionScraper now takes in a list of urls to scrape rather than
just one.
Change Players table to include a field for team name.